### PR TITLE
Fixing bug with names. Mosquitto module uses 'str' type for _client_i…

### DIFF
--- a/python/debian/changelog
+++ b/python/debian/changelog
@@ -1,3 +1,9 @@
+python-mqttrpc (1.1.2) UNRELEASED; urgency=medium
+
+  * 
+
+ -- Ekaterina Volkova <ekaterina.volkova@wirenboard.ru>  Wed, 16 Mar 2022 11:57:48 +0300
+
 python-mqttrpc (1.1.1) stable; urgency=medium
 
   * fix python dependency

--- a/python/debian/changelog
+++ b/python/debian/changelog
@@ -1,6 +1,6 @@
-python-mqttrpc (1.1.2) UNRELEASED; urgency=medium
+python-mqttrpc (1.1.2) stable; urgency=medium
 
-  * 
+  * add compatibility paho and mosquitto mqtt client id
 
  -- Ekaterina Volkova <ekaterina.volkova@wirenboard.ru>  Wed, 16 Mar 2022 11:57:48 +0300
 

--- a/python/mqttrpc/client.py
+++ b/python/mqttrpc/client.py
@@ -1,4 +1,5 @@
 import json
+import six
 
 try:
     import mosquitto
@@ -61,13 +62,10 @@ class TMQTTRPCClient(object):
         self.counter = 0
         self.futures = {}
         self.subscribes = set()
-        typename = str(type(self.client._client_id))
-        if typename=="<class 'bytes'>": #Python3
+        if six.PY3 and type(self.client._client_id) is bytes:
             self.rpc_client_id = self.client._client_id.decode().replace('/','_')
-        elif typename=="<type 'unicode'>": #Python2
-            self.rpc_client_id = str(self.client._client_id).replace('/','_')
         else:
-            self.rpc_client_id = self.client._client_id.replace('/','_')
+            self.rpc_client_id = str(self.client._client_id).replace('/','_')
 
     def on_mqtt_message(self, mosq, obj, msg):
         """ return True if the message was indeed an rpc call"""

--- a/python/mqttrpc/client.py
+++ b/python/mqttrpc/client.py
@@ -61,7 +61,13 @@ class TMQTTRPCClient(object):
         self.counter = 0
         self.futures = {}
         self.subscribes = set()
-        self.rpc_client_id = self.client._client_id.replace('/','_')
+        typename = str(type(self.client._client_id))
+        if typename=="<class 'bytes'>": #Python3
+            self.rpc_client_id = self.client._client_id.decode().replace('/','_')
+        elif typename=="<type 'unicode'>": #Python2
+            self.rpc_client_id = str(self.client._client_id).replace('/','_')
+        else:
+            self.rpc_client_id = self.client._client_id.replace('/','_')
 
     def on_mqtt_message(self, mosq, obj, msg):
         """ return True if the message was indeed an rpc call"""


### PR DESCRIPTION
…d, while paho is 'bytes'.