### PR TITLE
fix error with python 3.10

### DIFF
--- a/python/mqttrpc/dispatcher.py
+++ b/python/mqttrpc/dispatcher.py
@@ -4,6 +4,11 @@ For usage examples see :meth:`Dispatcher.add_method`
 
 """
 import collections
+try:
+    from collections import abc
+    collections.MutableMapping = abc.MutableMapping
+except:
+    pass
 
 
 class Dispatcher(collections.MutableMapping):


### PR DESCRIPTION
In python 3.10, the attribute MutableMapping from the module `collections` have been moved to `collections.abc`.
Error:
```
AttributeError: module 'collections' has no attribute 'MutableMapping'
```